### PR TITLE
Feature/telemetry usage

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -98,3 +98,33 @@ spec:
     secretName: {{ .Values.deployment.ingress.downloads.downloads_tls_secret }}
 
 {{ end }} # end of ingress enabled check defined in the beginning
+
+{{ if .Values.telemetry.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: {{ .Values.global.namespace }}
+  annotations:
+    cert-manager.io/cluster-issuer: ov-issuer
+    dns.operators.ecmwf.int/on-transport-server: vs-transport-https
+    nginx.org/redirect-to-https: "True"
+  name: polytope-ingress-telemetry
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: "telemetry-{{ .Values.deployment.ingress.deployment_name }}.{{ .Values.deployment.ingress.common_domain }}"
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ .Values.telemetry.host }}
+            port:
+              number: {{ .Values.telemetry.port }}
+        path: /telemetry/v1/metrics
+        pathType: Prefix
+  tls:
+  - hosts:
+    - "telemetry-{{ .Values.deployment.ingress.deployment_name }}.{{ .Values.deployment.ingress.common_domain }}"
+    secretName: {{ .Values.telemetry.ingress.telemetry_tls_secret}}
+{{ end}}

--- a/templates/telemetry.yaml
+++ b/templates/telemetry.yaml
@@ -76,7 +76,7 @@ spec:
           {{- end }}
         readinessProbe:
           httpGet:
-            path: /telemetry/v1/test
+            path: /telemetry/v1/health
             port: {{ .Values.telemetry.port }}
           initialDelaySeconds: 1
           periodSeconds: 60

--- a/templates/telemetry.yaml
+++ b/templates/telemetry.yaml
@@ -79,7 +79,7 @@ spec:
             path: /telemetry/v1/health
             port: {{ .Values.telemetry.port }}
           initialDelaySeconds: 1
-          periodSeconds: 60
+          periodSeconds: 10
       volumes:
         - name: config-volume
           configMap:

--- a/values.yaml
+++ b/values.yaml
@@ -283,6 +283,16 @@ telemetry:
   host: telemetry
   port: 32012
   bind_to: 0.0.0.0
+  obfuscate_apikeys: True # obfuscate api keys in the endpoints
+  usage:
+    enabled: True
+    cache_expiry_seconds: 30 # set a value similar to prometheus scrape interval, default is 30 seconds
+    timeframes: # in s/h/d format, it controls the timeframes for which the usage is calculated in /usage endpoint
+      - 12h
+      - 1d
+      - 3d
+      - 7d
+      - 30d
 
 metric_store:
   mongodb:
@@ -333,6 +343,7 @@ garbage-collector:
   interval: 10s
   threshold: 1T
   age: 3d
+  metric_age: 30d # we keep processed metrics for long time for /usage endpoint
 
 # The last two sections are very deployment specific, so we're only leaving some examples here
 #################################################################################################

--- a/values.yaml
+++ b/values.yaml
@@ -293,6 +293,17 @@ telemetry:
       - 3d
       - 7d
       - 30d
+  ingress:
+    enabled: false 
+    telemetry_tls_secret: # deployment specific
+  basic_auth:
+    enabled: false 
+    log_suppression_ttl: 3600 # in seconds
+    users:
+      - attributes: {}
+        password: # deployment specific
+        uid: # deployment specific
+    
 
 metric_store:
   mongodb:


### PR DESCRIPTION
This PR is complementary to [#58](https://github.com/ecmwf/polytope-server/pull/58) and includes:

- **New Defaults for Telemetry Service:** Provides improved baseline configurations.
- **Ingress for Telemetry:** Facilitates external access to the telemetry service.
- **Readiness Change for Telemetry:** Updates the readiness with new endpoint