### PR TITLE
Conditionally create imagePullSecret

### DIFF
--- a/templates/broker.yaml
+++ b/templates/broker.yaml
@@ -64,7 +64,9 @@ spec:
         - name: config-volume
           configMap:
             name: polytope-config
+      {{ if .Values.deployment.imageCredentials }}
       imagePullSecrets:
         - name: polytope-registry-cred
+      {{ end }}
 
 {{ end }}

--- a/templates/frontend.yaml
+++ b/templates/frontend.yaml
@@ -77,8 +77,10 @@ spec:
         - name: config-volume
           configMap:
             name: polytope-config
+      {{ if .Values.deployment.imageCredentials }}
       imagePullSecrets:
         - name: polytope-registry-cred
+      {{ end }}
 ---
 
 apiVersion: v1

--- a/templates/garbage-collector.yml
+++ b/templates/garbage-collector.yml
@@ -61,7 +61,9 @@ spec:
         - name: config-volume
           configMap:
             name: polytope-config
+      {{ if .Values.deployment.imageCredentials }}
       imagePullSecrets:
         - name: polytope-registry-cred
+      {{ end }}
 
 {{ end }}

--- a/templates/pull-secret.yaml
+++ b/templates/pull-secret.yaml
@@ -6,6 +6,8 @@
 
 ---
 
+{{ if .Values.deployment.imageCredentials }}
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,3 +16,5 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}
+
+{{ end }}

--- a/templates/telemetry.yaml
+++ b/templates/telemetry.yaml
@@ -84,8 +84,10 @@ spec:
         - name: config-volume
           configMap:
             name: polytope-config
+      {{ if .Values.deployment.imageCredentials }}
       imagePullSecrets:
         - name: polytope-registry-cred
+      {{ end }}
 ---
 
 apiVersion: v1

--- a/templates/worker.yaml
+++ b/templates/worker.yaml
@@ -131,8 +131,10 @@ spec:
         {{ end }}
       securityContext:
         fsGroup: 1500
+      {{ if .Values.deployment.imageCredentials }}
       imagePullSecrets:
         - name: polytope-registry-cred
+      {{ end }}
   {{ if .Values.deployment.worker_node }}
   affinity:
     nodeAffinity:
@@ -372,7 +374,6 @@ roleRef:
   kind: Role
   name: mars-client
   apiGroup: rbac.authorization.k8s.io
-
 
 
 


### PR DESCRIPTION
When imageCredentials are not populated, attempting to create the imagePullSecret will fail. Skip the creation in this case.