### PR TITLE
Add option to set extra environment variables

### DIFF
--- a/templates/broker.yaml
+++ b/templates/broker.yaml
@@ -55,6 +55,18 @@ spec:
           limits:
             memory: "1Gi"
             cpu: "0.5"
+        {{- if .Values.deployment.default.extraEnvironmentVars }}
+        env:
+        {{- range $key, $value := .Values.deployment.default.extraEnvironmentVars }}
+        - name: {{ $key }}
+        {{- if kindIs "string" $value }}
+          value: {{ $value | quote }}
+        {{- else }}
+          valueFrom:
+            {{ toYaml $value | nindent 12 | trim }}
+        {{- end -}}
+        {{- end }}
+        {{- end }}
         volumeMounts:
           - name: config-volume
             mountPath: /etc/polytope

--- a/templates/frontend.yaml
+++ b/templates/frontend.yaml
@@ -65,6 +65,17 @@ spec:
               fieldPath: status.hostIP
         - name: POLYTOPE_PROXY
           value: {{ .Values.deployment.polytope_proxy }}
+        {{- if .Values.deployment.default.extraEnvironmentVars }}
+        {{- range $key, $value := .Values.deployment.default.extraEnvironmentVars }}
+        - name: {{ $key }}
+        {{- if kindIs "string" $value }}
+          value: {{ $value | quote }}
+        {{- else }}
+          valueFrom:
+            {{ toYaml $value | nindent 12 | trim }}
+        {{- end -}}
+        {{- end }}
+        {{- end }}
         command: ["python"]
         args: ["-m", "polytope_server.frontend"]
         readinessProbe:

--- a/templates/garbage-collector.yml
+++ b/templates/garbage-collector.yml
@@ -52,6 +52,20 @@ spec:
           limits:
             memory: "2Gi"
             cpu: "0.5"
+        {{ if .Values.deployment.default.extraEnvironmentVars }}
+        env:
+        {{- if .Values.deployment.default.extraEnvironmentVars }}
+        {{- range $key, $value := .Values.deployment.default.extraEnvironmentVars }}
+        - name: {{ $key }}
+        {{- if kindIs "string" $value }}
+          value: {{ $value | quote }}
+        {{- else }}
+          valueFrom:
+            {{ toYaml $value | nindent 12 | trim }}
+        {{- end -}}
+        {{- end }}
+        {{- end }}
+        {{ end }}
         volumeMounts:
           - name: config-volume
             mountPath: /etc/polytope

--- a/templates/telemetry.yaml
+++ b/templates/telemetry.yaml
@@ -61,6 +61,17 @@ spec:
           value: {{ .Values.deployment.polytope_proxy }}
         - name: TELEMETRY_PORT
           value: "{{ .Values.telemetry.port }}"
+        {{- if .Values.deployment.default.extraEnvironmentVars }}
+        {{- range $key, $value := .Values.deployment.default.extraEnvironmentVars }}
+        - name: {{ $key }}
+        {{- if kindIs "string" $value }}
+          value: {{ $value | quote }}
+        {{- else }}
+          valueFrom:
+            {{ toYaml $value | nindent 12 | trim }}
+        {{- end -}}
+        {{- end }}
+        {{- end }}
         command: ["uvicorn"]
         args:
           - "polytope_server.telemetry.main:app"

--- a/templates/worker.yaml
+++ b/templates/worker.yaml
@@ -83,6 +83,17 @@ spec:
             value: {{ .Values.logging.mars_debug | quote | default "0" }}
           - name: FDB_DEBUG
             value: {{ .Values.logging.fdb_debug | quote | default "0" }}
+          {{- if .Values.deployment.default.extraEnvironmentVars }}
+          {{- range $key, $value := .Values.deployment.default.extraEnvironmentVars }}
+          - name: {{ $key }}
+          {{- if kindIs "string" $value }}
+            value: {{ $value | quote }}
+          {{- else }}
+            valueFrom:
+              {{ toYaml $value | nindent 14 | trim }}
+          {{- end -}}
+          {{- end }}
+          {{- end }}
         volumeMounts:
           - name: config-volume
             mountPath: /etc/polytope
@@ -372,7 +383,6 @@ roleRef:
   kind: Role
   name: mars-client
   apiGroup: rbac.authorization.k8s.io
-
 
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -223,7 +223,8 @@ deployment:
 
   default:
     extraEnvironmentVars:
-      # STRING_VAR_NAME: value
+      # you can add additional environment variables either as strings or secrets for first party polytope services to be used in config substitution
+      # STRING_VAR_NAME: "value"
       # MAP_VAR_NAME:
       #   secretKeyRef:
       #     name: secret-name

--- a/values.yaml
+++ b/values.yaml
@@ -221,6 +221,13 @@ deployment:
       # -----END OPENSSH PRIVATE KEY-----
     # sshPublicKey:
 
+  default:
+    extraEnvironmentVars:
+      # STRING_VAR_NAME: value
+      # MAP_VAR_NAME:
+      #   secretKeyRef:
+      #     name: secret-name
+      #     key: secret-key
   imageCredentials:
     registry: 
     username: 


### PR DESCRIPTION
Create an additional map in deployment.default.extraEnvironmentVars that allows the user to provide variables that are put in all of the first-party polytope deployments.

This follows the model used by seaweedfs that allows both string and secret variables.