### PR TITLE
Condition creation of mars ServiceAccount on if mars_c is enabled

### DIFF
--- a/templates/worker.yaml
+++ b/templates/worker.yaml
@@ -349,6 +349,7 @@ spec:
 # Service account rules give the mars-wrapper the ability to do "get" on the "services" endpoint,
 # allowing it to query the assigned nodeport
 
+{{ if .Values.deployment.mars_c.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -372,7 +373,7 @@ roleRef:
   kind: Role
   name: mars-client
   apiGroup: rbac.authorization.k8s.io
-
+{{ end }}
 
 
 


### PR DESCRIPTION
Deployments that are not using a mars client don't need to create the service account, add a condition.