### PR TITLE
Update configmap conditions on .Values.staging

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -26,28 +26,15 @@ metadata:
 data:
   config.yaml: |-
 {{- $config := .Values | deepCopy }}
-{{- if .Values.seaweedfs.enabled }}
-  {{- if .Values.staging.s3_boto3 }}
-    {{- $_ := set $config.staging.s3_boto3 "host" "http://seaweedfs-s3" }}
-    {{- $_ := set $config.staging.s3_boto3 "should_set_policy" false }}
-  {{- end }}
-{{- else }}
-  {{- if .Values.staging.s3_boto3 }}
-    {{- $_ := set $config.staging.s3_boto3 "should_set_policy" true }}
-  {{- end }}
-{{- end }}
 
-{{- if .Values.seaweedfs.enabled }}
-  {{- if .Values.staging.s3 }}
+{{- if (.Values.staging).s3 }}
+  {{- $_ := set $config.staging.s3 "url" (printf "download-%s.%s" .Values.deployment.ingress.deployment_name .Values.deployment.ingress.common_domain) }}
+  {{- if .Values.seaweedfs.enabled }}
     {{- $_ := set $config.staging.s3 "host" "http://seaweedfs-s3" }}
     {{- $_ := set $config.staging.s3 "should_set_policy" false }}
-  {{- end }}
-{{- else }}
-  {{- if .Values.staging.s3 }}
+  {{- else }}
     {{- $_ := set $config.staging.s3 "should_set_policy" true }}
   {{- end }}
 {{- end }}
-
-{{- $_ := set $config.staging.s3_boto3 "url" (printf "download-%s.%s" .Values.deployment.ingress.deployment_name .Values.deployment.ingress.common_domain) }}
 
 {{ $config | toYaml | indent 6 }}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -27,23 +27,23 @@ data:
   config.yaml: |-
 {{- $config := .Values | deepCopy }}
 {{- if .Values.seaweedfs.enabled }}
-  {{- if hasKey .Values.staging "s3_boto3" }}
+  {{- if .Values.staging.s3_boto3 }}
     {{- $_ := set $config.staging.s3_boto3 "host" "http://seaweedfs-s3" }}
     {{- $_ := set $config.staging.s3_boto3 "should_set_policy" false }}
   {{- end }}
 {{- else }}
-  {{- if hasKey .Values.staging "s3_boto3" }}
+  {{- if .Values.staging.s3_boto3 }}
     {{- $_ := set $config.staging.s3_boto3 "should_set_policy" true }}
   {{- end }}
 {{- end }}
 
 {{- if .Values.seaweedfs.enabled }}
-  {{- if hasKey .Values.staging "s3" }}
+  {{- if .Values.staging.s3 }}
     {{- $_ := set $config.staging.s3 "host" "http://seaweedfs-s3" }}
     {{- $_ := set $config.staging.s3 "should_set_policy" false }}
   {{- end }}
 {{- else }}
-  {{- if hasKey .Values.staging "s3" }}
+  {{- if .Values.staging.s3 }}
     {{- $_ := set $config.staging.s3 "should_set_policy" true }}
   {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -365,7 +365,7 @@ testrunner:
   port: 5000
 
 staging:
-  s3_boto3:
+  s3:
     access_key: *s3_access_key
     buffer_size: 10971520
     host: *download_host


### PR DESCRIPTION
Change hasKey conditions to a nil/false check when updating staging in the configmap.

If a client overrides the default staging.s3_boto3 to null in order to set a different staging area, then hasKey still returns true and the subsequent set operation fails. Checking the value directly will result in a false evaluation in this case.