### PR TITLE
Allow disabling the downloads ingress

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -48,6 +48,8 @@ data:
   {{- end }}
 {{- end }}
 
-{{- $_ := set $config.staging.s3_boto3 "url" (printf "download-%s.%s" .Values.deployment.ingress.deployment_name .Values.deployment.ingress.common_domain) }}
+{{- if and .Values.deployment.ingress.downloads.enabled .Values.staging.s3_boto3 }}
+    {{- $_ := set $config.staging.s3_boto3 "url" (printf "download-%s.%s" .Values.deployment.ingress.deployment_name .Values.deployment.ingress.common_domain) }}
+{{- end }}
 
 {{ $config | toYaml | indent 6 }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -37,14 +37,14 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: {{ .Values.deployment.ingress.frontend.host }}
+            name: {{ .Values.frontend.host }}
             port:
-              number: {{ .Values.deployment.ingress.frontend.port }}
+              number: {{ .Values.frontend.port }}
   defaultBackend:
     service:
-      name: {{ .Values.deployment.ingress.frontend.host }}
+      name: {{ .Values.frontend.host }}
       port:
-        number: {{ .Values.deployment.ingress.frontend.port }}
+        number: {{ .Values.frontend.port }}
   tls:
   - hosts:
     - "{{ .Values.deployment.ingress.deployment_name }}.{{ .Values.deployment.ingress.common_domain }}"
@@ -52,7 +52,7 @@ spec:
 
 {{ end }} # end of ingress frontend enabled check
 
-{{ if .Values.ingress.downloads.enabled }}
+{{ if .Values.deployment.ingress.downloads.enabled }}
 ---
 
 apiVersion: networking.k8s.io/v1
@@ -72,7 +72,7 @@ spec:
       paths:
       - backend:
           service:
-            name: "{{- if .Values.seaweedfs.enabled }}seaweedfs-s3{{- else }}{{ .Values.download_host }}{{- end }}"
+            name: "{{- if .Values.seaweedfs.enabled }}seaweedfs-s3{{- else }}{{ .Values.deployment.ingress.downloads.host }}{{- end }}"
             port:
               number: {{ .Values.deployment.ingress.downloads.port }}
         path: /
@@ -84,14 +84,14 @@ spec:
 
 {{ end }} # end of ingress download enabled check
 
-{{ if .Values.telemetry.ingress.enabled }}
+{{ if .Values.deployment.ingress.telemetry.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: {{ .Values.global.namespace }}
   annotations:
-    {{- with .Values.telemetry.ingress.annotations }}
+    {{- with .Values.deployment.ingress.telemetry.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   name: polytope-ingress-telemetry
@@ -111,5 +111,5 @@ spec:
   tls:
   - hosts:
     - "telemetry-{{ .Values.deployment.ingress.deployment_name }}.{{ .Values.deployment.ingress.common_domain }}"
-    secretName: {{ .Values.telemetry.ingress.telemetry_tls_secret}}
+    secretName: {{ .Values.deployment.ingress.telemetry.tls_secret}}
 {{ end}}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -60,7 +60,7 @@ kind: Ingress
 metadata:
   namespace: {{ .Values.global.namespace }}
   annotations: 
-    {{- with .Values.deployment.ingress.download.annotations }}
+    {{- with .Values.deployment.ingress.downloads.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   name: polytope-ingress-downloads
@@ -80,7 +80,7 @@ spec:
   tls:
   - hosts:
     - "download-{{ .Values.deployment.ingress.deployment_name }}.{{ .Values.deployment.ingress.common_domain }}"
-    secretName: {{ .Values.deployment.ingress.downloads.downloads.tls_secret }}
+    secretName: {{ .Values.deployment.ingress.downloads.tls_secret }}
 
 {{ end }} # end of ingress download enabled check
 

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -17,14 +17,14 @@
 ## granted to it by virtue of its status as an intergovernmental organisation nor
 ## does it submit to any jurisdiction.
 ##
-{{ if .Values.deployment.ingress.enabled }}
+{{ if .Values.deployment.ingress.frontend.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: polytope-ingress
   namespace: {{ .Values.global.namespace }}
   annotations:
-    {{- with .Values.deployment.ingress.frontend_annotations }}
+    {{- with .Values.deployment.ingress.frontend.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
@@ -37,19 +37,22 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: {{ .Values.deployment.ingress.host }}
+            name: {{ .Values.deployment.ingress.frontend.host }}
             port:
-              number: {{ .Values.deployment.ingress.port }}
+              number: {{ .Values.deployment.ingress.frontend.port }}
   defaultBackend:
     service:
-      name: {{ .Values.deployment.ingress.host }}
+      name: {{ .Values.deployment.ingress.frontend.host }}
       port:
-        number: {{ .Values.deployment.ingress.port }}
+        number: {{ .Values.deployment.ingress.frontend.port }}
   tls:
   - hosts:
     - "{{ .Values.deployment.ingress.deployment_name }}.{{ .Values.deployment.ingress.common_domain }}"
-    secretName: {{ .Values.deployment.ingress.frontend_tls_secret }}
+    secretName: {{ .Values.deployment.ingress.frontend.tls_secret }}
 
+{{ end }} # end of ingress frontend enabled check
+
+{{ if .Values.ingress.downloads.enabled }}
 ---
 
 apiVersion: networking.k8s.io/v1
@@ -57,7 +60,7 @@ kind: Ingress
 metadata:
   namespace: {{ .Values.global.namespace }}
   annotations: 
-    {{- with .Values.deployment.ingress.download_annotations }}
+    {{- with .Values.deployment.ingress.download.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   name: polytope-ingress-downloads
@@ -77,9 +80,9 @@ spec:
   tls:
   - hosts:
     - "download-{{ .Values.deployment.ingress.deployment_name }}.{{ .Values.deployment.ingress.common_domain }}"
-    secretName: {{ .Values.deployment.ingress.downloads.downloads_tls_secret }}
+    secretName: {{ .Values.deployment.ingress.downloads.downloads.tls_secret }}
 
-{{ end }} # end of ingress enabled check defined in the beginning
+{{ end }} # end of ingress download enabled check
 
 {{ if .Values.telemetry.ingress.enabled }}
 ---

--- a/values.yaml
+++ b/values.yaml
@@ -228,13 +228,6 @@ deployment:
   ingress:
     common_domain: # deployment specific, e.g. ecmwf.int
     deployment_name: # deployment specific, e.g. polytope
-    frontend:
-      enabled: true
-      host: frontend
-      port: 32002
-      tls_secret:  # deployment specific
-      annotations:
-        # list all frontend ingress annotations
     downloads:
       enabled: true
       host: *download_host
@@ -242,6 +235,16 @@ deployment:
       tls_secret: # deployment specific
       annotations:
         # list all download ingress annotations
+    frontend:
+      enabled: true
+      tls_secret:  # deployment specific
+      annotations:
+        # list all frontend ingress annotations
+    telemetry:
+      annotations:
+        # list all telemetry ingress annotations
+      enabled: false
+      tls_secret: # deployment specific
       
   broker:
     replicas: 1
@@ -308,11 +311,6 @@ telemetry:
       - 3d
       - 7d
       - 30d
-  ingress:
-    annotations:
-      # list all telemetry ingress annotations
-    enabled: false 
-    telemetry_tls_secret: # deployment specific
   basic_auth:
     enabled: false 
     log_suppression_ttl: 3600 # in seconds

--- a/values.yaml
+++ b/values.yaml
@@ -226,21 +226,22 @@ deployment:
     username: 
     password: 
   ingress:
-    enabled: true
-    https_rewrite: true
-    host: frontend
-    port: 32002
-    public_endpoint_dns_name: # deployment specific, e.g. ecmwf.int
+    common_domain: # deployment specific, e.g. ecmwf.int
     deployment_name: # deployment specific, e.g. polytope
-    frontend_tls_secret:  # deployment specific
+    frontend:
+      enabled: true
+      host: frontend
+      port: 32002
+      tls_secret:  # deployment specific
+      annotations:
+        # list all frontend ingress annotations
     downloads:
+      enabled: true
       host: *download_host
       port: *download_port
-      downloads_tls_secret: # deployment specific
-    frontend_annotations: 
-      # list all frontend ingress annotations
-    download_annotations: 
-      # list all download ingress annotations
+      tls_secret: # deployment specific
+      annotations:
+        # list all download ingress annotations
       
   broker:
     replicas: 1

--- a/values.yaml
+++ b/values.yaml
@@ -241,10 +241,10 @@ deployment:
       annotations:
         # list all frontend ingress annotations
     telemetry:
-      annotations:
-        # list all telemetry ingress annotations
       enabled: false
       tls_secret: # deployment specific
+      annotations:
+        # list all telemetry ingress annotations
       
   broker:
     replicas: 1


### PR DESCRIPTION
Add a key to specify whether the download ingress should be enabled. When the staging is hosted outside of the cluster, this ingress is unnecessary and has no backend to route to.

Also update the structure of the ingress map so the config for frontend, download, and telemetry are all under the same header with a similar structure.