### PR TITLE
Fix/deployable default

### DIFF
--- a/charts/minio/templates/deployment.yaml
+++ b/charts/minio/templates/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: minio
-  namespace: {{ .Values.global.namespace | default .Release.Namespace }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:

--- a/charts/minio/templates/pvc.yaml
+++ b/charts/minio/templates/pvc.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: minio-pv-claim
-  namespace: {{ .Values.global.namespace | default .Release.Namespace }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/charts/minio/templates/service.yaml
+++ b/charts/minio/templates/service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.host }}
-  namespace: {{ .Values.global.namespace | default .Release.Namespace }}
 spec:
   type: NodePort
   ports:

--- a/templates/broker.yaml
+++ b/templates/broker.yaml
@@ -25,7 +25,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: broker
-  namespace: {{ .Values.global.namespace }}
   annotations:
     {{- with .Values.deployment.broker.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/templates/broker.yaml
+++ b/templates/broker.yaml
@@ -53,7 +53,7 @@ spec:
         {{ else }}
         image: {{ .Values.deployment.registry }}/polytope-common:{{ .Release.Namespace }}-latest
         {{ end }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.deployment.imagePullPolicy | default "IfNotPresent" }}
         resources:
           requests:
             memory: "128Mi"

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -22,7 +22,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: polytope-config
-  namespace: {{ .Values.global.namespace }}
 data:
   config.yaml: |-
 {{- $config := .Values | deepCopy }}

--- a/templates/configmap_template.yaml
+++ b/templates/configmap_template.yaml
@@ -25,7 +25,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: polytope-config-generic
-  namespace: {{ .Values.global.namespace }}
   annotations:
 
 data:

--- a/templates/frontend.yaml
+++ b/templates/frontend.yaml
@@ -25,7 +25,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
-  namespace: {{ .Values.global.namespace }}
   annotations:
     {{- with .Values.deployment.frontend.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -105,7 +104,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.frontend.host }}
-  namespace: {{ .Values.global.namespace }}
 spec:
   selector:
     app: frontend

--- a/templates/frontend.yaml
+++ b/templates/frontend.yaml
@@ -53,7 +53,7 @@ spec:
         {{ else }}
         image: {{ .Values.deployment.registry }}/polytope-common:{{ .Release.Namespace }}-latest
         {{ end }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.deployment.imagePullPolicy | default "IfNotPresent" }}
         resources:
           requests:
             memory: "128Mi"

--- a/templates/garbage-collector.yml
+++ b/templates/garbage-collector.yml
@@ -53,7 +53,7 @@ spec:
         {{ else }}
         image: {{ .Values.deployment.registry }}/polytope-common:{{ .Release.Namespace }}-latest
         {{ end }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.deployment.imagePullPolicy | default "IfNotPresent" }}
         resources:
           limits:
             memory: "2Gi"

--- a/templates/garbage-collector.yml
+++ b/templates/garbage-collector.yml
@@ -25,7 +25,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: garbage-collector
-  namespace: {{ .Values.global.namespace }}
   annotations:
     {{- with index .Values "deployment.garbage-collector.annotations" }}
     {{- toYaml . | nindent 4 }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -22,7 +22,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: polytope-ingress
-  namespace: {{ .Values.global.namespace }}
   annotations:
     {{- with .Values.deployment.ingress.frontend.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -58,7 +57,6 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  namespace: {{ .Values.global.namespace }}
   annotations: 
     {{- with .Values.deployment.ingress.downloads.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -89,7 +87,6 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  namespace: {{ .Values.global.namespace }}
   annotations:
     {{- with .Values.deployment.ingress.telemetry.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/templates/mars-ssh-secret.yaml
+++ b/templates/mars-ssh-secret.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: mars-ssh-secret
-    namespace: {{ .Release.Namespace }}
 data:
     id_rsa: {{ .Values.deployment.mars_c.sshPrivateKey | b64enc }}
     id_rsa.pub: {{ .Values.deployment.mars_c.sshPublicKey | b64enc }}

--- a/templates/polytope-staging.yaml
+++ b/templates/polytope-staging.yaml
@@ -25,7 +25,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: polytope-staging
-  namespace: {{ .Values.global.namespace }}
 spec:
   replicas: {{ .Values.deployment.polytope_staging.replicas }}
   selector:
@@ -53,7 +52,7 @@ spec:
           - name: config-volume
             mountPath: /etc/polytope
           - name: data
-            mountPath: {{ .Values.deployment.polytope_staging.root_dir }}
+            mountPath: {{ .Values.staging.polytope.root_dir | default "~/polytope/data" }}
         command: ["python"]
         args: ["-m", "polytope_server.basic_object_store"]
       volumes:
@@ -75,7 +74,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: polytope-staging
-  namespace: {{ .Values.global.namespace }}
 spec:
   accessModes:
     - ReadWriteOnce
@@ -88,8 +86,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.deployment.polytope_staging.host }}
-  namespace: {{ .Values.global.namespace }}
+  name: {{ .Values.staging.polytope.host | default "polytope-staging" }}
 spec:
   selector:
     app: polytope-staging
@@ -97,7 +94,7 @@ spec:
   ports:
   - protocol: TCP
     # nodePort: {{ .Values.deployment.polytope_staging.port }}
-    targetPort: {{ .Values.deployment.polytope_staging.port }}
-    port: {{ .Values.deployment.polytope_staging.port }}
+    targetPort: {{ .Values.staging.polytope.port | default 8000 }}
+    port: {{ .Values.staging.polytope.port | default 8000 }}
 
 {{ end }}

--- a/templates/polytope-staging.yaml
+++ b/templates/polytope-staging.yaml
@@ -47,7 +47,7 @@ spec:
         {{ else }}
         image: {{ .Values.deployment.registry }}/polytope-common:{{ .Release.Namespace }}-latest
         {{ end }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.deployment.imagePullPolicy | default "IfNotPresent" }}
         volumeMounts:
           - name: config-volume
             mountPath: /etc/polytope

--- a/templates/pull-secret.yaml
+++ b/templates/pull-secret.yaml
@@ -12,7 +12,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: polytope-registry-cred
-  namespace: {{ .Values.global.namespace }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}

--- a/templates/seaweedfs-secret-db.yaml
+++ b/templates/seaweedfs-secret-db.yaml
@@ -6,7 +6,6 @@ kind: Secret
 type: Opaque
 metadata:
   name: secret-seaweedfs-db
-  namespace: {{ .Values.global.namespace }}
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
@@ -30,7 +29,6 @@ kind: Secret
 type: Opaque
 metadata:
   name: {{ .Values.seaweedfs.createS3Secret.secretName }}
-  namespace: {{ .Values.global.namespace }}
   labels:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
     app.kubernetes.io/component: s3

--- a/templates/service_monitors.yaml
+++ b/templates/service_monitors.yaml
@@ -6,7 +6,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: seaweedfs-master-monitor
-  namespace: {{ .Values.global.namespace }}
 spec:
   selector:
     matchLabels:
@@ -29,7 +28,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: seaweedfs-filer-monitor
-  namespace: {{ .Values.global.namespace }}
 spec:
   selector:
     matchLabels:
@@ -48,7 +46,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: seaweedfs-filer-client-monitor
-  namespace: {{ .Values.global.namespace }}
 spec:
   selector:
     matchLabels:
@@ -71,7 +68,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: seaweedfs-volume-monitor
-  namespace: {{ .Values.global.namespace }}
 spec:
   selector:
     matchLabels:

--- a/templates/service_monitors.yaml
+++ b/templates/service_monitors.yaml
@@ -13,7 +13,7 @@ spec:
       app.kubernetes.io/name: seaweedfs
   namespaceSelector:
     matchNames:
-      - {{ .Values.global.namespace }}
+      - {{ .Release.Namespace }}
   endpoints:
     - port: metrics
       interval: 30s
@@ -35,7 +35,7 @@ spec:
       app.kubernetes.io/name: seaweedfs
   namespaceSelector:
     matchNames:
-      - {{ .Values.global.namespace }}
+      - {{ .Release.Namespace }}
   endpoints:
     - port: metrics
       interval: 30s
@@ -53,7 +53,7 @@ spec:
       app.kubernetes.io/name: seaweedfs
   namespaceSelector:
     matchNames:
-      - {{ .Values.global.namespace }}
+      - {{ .Release.Namespace }}
   endpoints:
     - port: metrics
       interval: 30s
@@ -75,7 +75,7 @@ spec:
       app.kubernetes.io/name: seaweedfs
   namespaceSelector:
     matchNames:
-      - {{ .Values.global.namespace }}
+      - {{ .Release.Namespace }}
   endpoints:
     - port: metrics
       interval: 30s

--- a/templates/telemetry.yaml
+++ b/templates/telemetry.yaml
@@ -54,7 +54,7 @@ spec:
         {{- else }}
         image: {{ .Values.deployment.registry }}/polytope-common:{{ .Release.Namespace }}-latest
         {{- end }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.deployment.imagePullPolicy | default "IfNotPresent" }}
         volumeMounts:
           - name: config-volume
             mountPath: /etc/polytope

--- a/templates/telemetry.yaml
+++ b/templates/telemetry.yaml
@@ -25,7 +25,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: telemetry
-  namespace: {{ .Values.global.namespace }}
   annotations:
     {{- with .Values.deployment.telemetry.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -112,7 +111,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.telemetry.host }}
-  namespace: {{ .Values.global.namespace }}
 spec:
   selector:
     app: telemetry

--- a/templates/worker.yaml
+++ b/templates/worker.yaml
@@ -27,7 +27,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: worker
-  namespace: {{ .Values.global.namespace }}
   annotations:
     {{- with .Values.deployment.worker.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -171,7 +170,6 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: worker
-  namespace: {{ .Values.global.namespace }}
 spec:
   replicas: {{ .Values.deployment.worker.replicas }}
   selector:
@@ -332,7 +330,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: worker-{{ $i }}
-  namespace: {{ $.Values.global.namespace }}
 spec:
   externalTrafficPolicy: Local # Only visible when accessing host node
   selector:
@@ -374,7 +371,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: mars-client
-  namespace: {{ .Values.global.namespace }}
 rules:
   - apiGroups: [""]
     resources: ["services"]
@@ -385,7 +381,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: mars-client
-  namespace: {{ .Values.global.namespace }}
 subjects:
   - kind: ServiceAccount
     name: default

--- a/templates/worker.yaml
+++ b/templates/worker.yaml
@@ -55,7 +55,7 @@ spec:
         {{ else }}
         image: {{ .Values.deployment.registry }}/worker:{{ .Release.Namespace }}-latest
         {{ end }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.deployment.imagePullPolicy | default "IfNotPresent" }}
         resources:
           {{ with .Values.deployment.worker.resources }}
           {{ toYaml . | nindent 10 }}
@@ -193,7 +193,7 @@ spec:
         {{ else }}
         image: {{ .Values.deployment.registry }}/worker:{{ .Release.Namespace }}-latest
         {{ end }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.deployment.imagePullPolicy | default "IfNotPresent" }}
         resources:
           {{ with .Values.deployment.worker.resources }}
           {{ toYaml . | nindent 10 }}

--- a/values.yaml
+++ b/values.yaml
@@ -255,8 +255,12 @@ minio:
 #################################################################################################
 
 deployment:
-  registry: mycluster-registry:0.0.0.0:5432 #eccr.ecmwf.int/polytope-pub
+  registry: eccr.ecmwf.int/polytope-pub
   tag: 1.5.1
+  # fqn_images: 
+  #   polytope_common: eccr.ecmwf.int/polytope-pub/polytope-common:1.5.1
+  #   worker: eccr.ecmwf.int/polytope-pub/worker:1.5.1
+  imagePullPolicy: IfNotPresent
   mars_c: # in certain environments you may need to use the mars c client
     enabled: false
     # the mars c client requires configuration which is currently accessed at runtime via git, so you need to provide an ssh key

--- a/values.yaml
+++ b/values.yaml
@@ -108,7 +108,7 @@ rabbitmq:
   networkPolicy:
     enabled: false
   metrics:
-    enabled: true
+    enabled: false
     serviceMonitor:
       enabled: true
       default:
@@ -129,17 +129,17 @@ mongodb:
   image:
     repository: bitnamilegacy/mongodb
   systemLogVerbosity: 0 #default value 0
-  replicaCount: 2 #default value 2
-  resourcesPreset: xlarge
+  replicaCount: 1 #default value 2
+  resourcesPreset: medium
   service:
     nameOverride: mongodb #required for polytope to find the mongodb service
   networkPolicy:
     enabled: false #default value true but we dont need it
   persistence:
-    enabled: true
-    size: 20Gi #default value 8Gi
+    enabled: false
+    # size: 20Gi #default value 8Gi
   metrics:
-    enabled: true
+    enabled: false
     image:
       repository: bitnamilegacy/mongodb-exporter
     collector:
@@ -256,7 +256,7 @@ minio:
 
 deployment:
   registry: eccr.ecmwf.int/polytope-pub
-  tag: 1.5.0
+  tag: 1.5.1
   mars_c: # in certain environments you may need to use the mars c client
     enabled: false
     # the mars c client requires configuration which is currently accessed at runtime via git, so you need to provide an ssh key
@@ -281,14 +281,14 @@ deployment:
     common_domain: # deployment specific, e.g. ecmwf.int
     deployment_name: # deployment specific, e.g. polytope
     downloads:
-      enabled: true
+      enabled: false
       host: *download_host
       port: *download_port
       tls_secret: # deployment specific
       annotations:
         # list all download ingress annotations
     frontend:
-      enabled: true
+      enabled: false
       tls_secret:  # deployment specific
       annotations:
         # list all frontend ingress annotations

--- a/values.yaml
+++ b/values.yaml
@@ -27,7 +27,7 @@ developer:
   disable_schema_check: true
 
 logging:
-  level: INFO
+  level: DEBUG
   mars_debug: 0
   fdb_debug: 0
 #################################################################################################
@@ -309,6 +309,7 @@ deployment:
     template_annotations:
         # list all broker template annotations
 
+  nodeport: 32002 # this is the nodeport for the frontend service, it must be between 30000 and 32767
   frontend:
     replicas: 1
     annotations:
@@ -474,7 +475,7 @@ authentication:
       plain:
         type: plain
         users:
-          - username: test # REPLACE
+          - uid: test # REPLACE
             password: test # REPLACE
             roles:
               - default

--- a/values.yaml
+++ b/values.yaml
@@ -57,37 +57,37 @@ download_port: &download_port 9000
 #################################################################################################
 
 auth-o-tron:
-  enabled: true
-  image:
-    pullPolicy: Always
-    tag: 0.2.8dev
-  config:
-    version: 1.0.0
-    logging:
-      level: "debug"
-      format: "json"
-    auth:
-      timeout_in_ms: 3000 # 3 seconds
-    providers:
-      - name: "Plain Provider"
-        type: "plain"
-        realm: "test-realm"
-        users:
-          - username: admin
-            password: admin
-            roles:
-              - polytope-admin
-    store:
-      enabled: false
-      # type: mongo
-      # database: tokens
-      # uri: mongodb://mongodb:27017
-    services: []
-    jwt:
-      exp: 3600
-      iss: authotron
-      secret: 6ec91aa8de4b579b5b6b87c289b5c818
-    bind_address: 0.0.0.0:8080
+  enabled: false
+#   image:
+#     pullPolicy: Always
+#     tag: 0.2.8dev
+#   config:
+#     version: 1.0.0
+#     logging:
+#       level: "debug"
+#       format: "json"
+#     auth:
+#       timeout_in_ms: 3000 # 3 seconds
+#     providers:
+#       - name: "Plain Provider"
+#         type: "plain"
+#         realm: "test-realm"
+#         users:
+#           - username: admin
+#             password: admin
+#             roles:
+#               - polytope-admin
+#     store:
+#       enabled: false
+#       # type: mongo
+#       # database: tokens
+#       # uri: mongodb://mongodb:27017
+#     services: []
+#     jwt:
+#       exp: 3600
+#       iss: authotron
+#       secret: 6ec91aa8de4b579b5b6b87c289b5c818
+#     bind_address: 0.0.0.0:8080
 
 
 rabbitmq:
@@ -255,7 +255,7 @@ minio:
 #################################################################################################
 
 deployment:
-  registry: eccr.ecmwf.int/polytope-pub
+  registry: mycluster-registry:0.0.0.0:5432 #eccr.ecmwf.int/polytope-pub
   tag: 1.5.1
   mars_c: # in certain environments you may need to use the mars c client
     enabled: false
@@ -452,17 +452,29 @@ garbage-collector:
 #################################################################################################
 #                                A U T H - O - T R O N   A U T H E N T I C A T I O N
 #################################################################################################
-authentication:
-  auth-o-tron:
-    url: http://auth-o-tron-svc:8080
-    secret: 6ec91aa8de4b579b5b6b87c289b5c818
+# authentication:
+#   auth-o-tron:
+#     url: http://auth-o-tron-svc:8080
+#     secret: 6ec91aa8de4b579b5b6b87c289b5c818
 
 #################################################################################################
 #            L E G A C Y   A U T H E N T I C A T I O N   &   A U T H O R I Z A T I O N
 #################################################################################################
 
-# authentication:
-#   ####################################
+authentication:
+####################################
+#       T E S T   R E A L M
+####################################
+  test-realm: # realm name
+    authenticators:
+      plain:
+        type: plain
+        users:
+          - username: test # REPLACE
+            password: test # REPLACE
+            roles:
+              - default
+  ####################################
 #   #       E C M W F   R E A L M
 #   ####################################
 
@@ -675,8 +687,10 @@ datasources:
 
 collections:
   dummy:
+    limits:
+      total: 1 # in case this accidentally does not get overridden, we set a low limit
     roles:
-      test-realm: [ default] # everybody gets default role
+      test-realm: [ default ] # everybody gets default role
     datasources:
     - name: dummy
 #   ecmwf-mars:

--- a/values.yaml
+++ b/values.yaml
@@ -30,6 +30,7 @@ logging:
   level: DEBUG
   mars_debug: 0
   fdb_debug: 0
+  mode: json
 #################################################################################################
 #                                        C O M M O N
 #################################################################################################
@@ -60,7 +61,7 @@ auth-o-tron:
   enabled: false
 #   image:
 #     pullPolicy: Always
-#     tag: 0.2.8dev
+#     tag: 0.2.8
 #   config:
 #     version: 1.0.0
 #     logging:
@@ -243,12 +244,12 @@ seaweedfs:
       WEED_MYSQL_HOSTNAME: *mysql_svc_name
 minio:
   enabled: false
-  host: *download_host
-  port: *download_port
-  size: 1Ti
-  replicas: 1
-  s3_access_key: *s3_access_key
-  s3_secret_key: *s3_secret_key
+#   host: *download_host
+#   port: *download_port
+#   size: 1Ti
+#   replicas: 1
+#   s3_access_key: *s3_access_key
+#   s3_secret_key: *s3_secret_key
 
 #################################################################################################
 #                   D E P L O Y M E N T

--- a/values.yaml
+++ b/values.yaml
@@ -19,7 +19,6 @@
 ##
 
 global:
-  namespace: my-namespace
   # to allow us to use bitnami legacy images 
   security:
     allowInsecureImages: true
@@ -58,7 +57,38 @@ download_port: &download_port 9000
 #################################################################################################
 
 auth-o-tron:
-  enabled: false
+  enabled: true
+  image:
+    pullPolicy: Always
+    tag: 0.2.8dev
+  config:
+    version: 1.0.0
+    logging:
+      level: "debug"
+      format: "json"
+    auth:
+      timeout_in_ms: 3000 # 3 seconds
+    providers:
+      - name: "Plain Provider"
+        type: "plain"
+        realm: "test-realm"
+        users:
+          - username: admin
+            password: admin
+            roles:
+              - polytope-admin
+    store:
+      enabled: false
+      # type: mongo
+      # database: tokens
+      # uri: mongodb://mongodb:27017
+    services: []
+    jwt:
+      exp: 3600
+      iss: authotron
+      secret: 6ec91aa8de4b579b5b6b87c289b5c818
+    bind_address: 0.0.0.0:8080
+
 
 rabbitmq:
   enabled: true
@@ -225,8 +255,8 @@ minio:
 #################################################################################################
 
 deployment:
-  registry:
-  tag:
+  registry: eccr.ecmwf.int/polytope-pub
+  tag: 1.5.0
   mars_c: # in certain environments you may need to use the mars c client
     enabled: false
     # the mars c client requires configuration which is currently accessed at runtime via git, so you need to provide an ssh key
@@ -294,6 +324,9 @@ deployment:
   minio:
     host: staging
     port: 9000
+    replicas: 1
+
+  polytope_staging:
     replicas: 1
 
   telemetry:
@@ -396,14 +429,18 @@ testrunner:
   port: 5000
 
 staging:
-  s3:
-    access_key: *s3_access_key
-    buffer_size: 10971520
-    host: *download_host
-    max_threads: 10
-    port: *download_port
-    secret_key: *s3_secret_key
-    use_ssl: true
+  polytope:
+    host: staging
+    port: 8000
+    root_dir: /home/polytope/data
+  # s3:
+  #   access_key: *s3_access_key
+  #   buffer_size: 10971520
+  #   host: *download_host
+  #   max_threads: 10
+  #   port: *download_port
+  #   secret_key: *s3_secret_key
+  #   use_ssl: true
 
 garbage-collector:
   interval: 10s
@@ -415,10 +452,10 @@ garbage-collector:
 #################################################################################################
 #                                A U T H - O - T R O N   A U T H E N T I C A T I O N
 #################################################################################################
-# authentication:
-#   auth-o-tron:
-#     url: http://auth-o-tron-svc:8080
-#     secret: your_secret
+authentication:
+  auth-o-tron:
+    url: http://auth-o-tron-svc:8080
+    secret: 6ec91aa8de4b579b5b6b87c289b5c818
 
 #################################################################################################
 #            L E G A C Y   A U T H E N T I C A T I O N   &   A U T H O R I Z A T I O N
@@ -488,7 +525,7 @@ garbage-collector:
 #################################################################################################
 ## Datasources are inheritable, so one could list parent datasources that get merged in order,
 ## with each new config overwriting the previous if there are conflicts. The child config is the last overwrite.
-# datasources:
+datasources:
 #   mars_c:
 #     type: mars
 #     #command: /usr/local/bin/mars
@@ -633,10 +670,15 @@ garbage-collector:
 #   raise:
 #     type: raise
 
-#   dummy:
-#     type: dummy
+  dummy:
+    type: dummy
 
-# collections:
+collections:
+  dummy:
+    roles:
+      test-realm: [ default] # everybody gets default role
+    datasources:
+    - name: dummy
 #   ecmwf-mars:
 #     roles: # per realm
 #       ecmwf: [  ]


### PR DESCRIPTION
### Description
Dev velocity improvement allowing one to run polytope locally with a dummy datasource using the default values.
- remove global namespace enforcement since subcharts don't respect it anyway
- values changes:
  - add example auth-o-tron config
  - disable metrics on rabbitmq, mongodb
  - reduce default mongodb to 1 replica with medium resource preset
  - no longer persistent by default
  - add default imagePullPolicy: IfNotPresent (previously defaulted to Always via template)
  - disable ingresses by default
  - add default frontend nodeport to enable local development
  - default to polytope-staging (suggest overwriting)
  - default to using plain legacy auth
  - add default dummy datasource and collection

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 