### PR TITLE
refactor: rename persist_after_secs → persist_after_ms, internal_poll_endpoint → internal_poll_base_url

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -29,8 +29,8 @@ data:
           init_max_attempts: {{ . }}
           {{- end }}
         {{- end }}
-        internal_poll_endpoint: {{ include "polytope-server.pollBaseUrl" . | quote }}
-        persist_after_secs: {{ .Values.frontend.persist_after_secs | default 10.0 }}
+        internal_poll_base_url: {{ include "polytope-server.pollBaseUrl" . | quote }}
+        persist_after_ms: {{ .Values.frontend.persist_after_ms | default 10000 }}
         worker_server:
           host: "0.0.0.0"
           port: {{ .Values.frontend.brokerPort | default 9001 }}

--- a/values.yaml
+++ b/values.yaml
@@ -26,7 +26,7 @@ frontend:
   port: 3000
   brokerPort: 9001
   replicas: 1
-  persist_after_secs: 10.0
+  persist_after_ms: 10000
   # max_jobs: 500000              # Broker-wide job limit (OOM protection, default 500000)
   # retry_after_secs: 5           # Retry-After header on 529 overload responses
   # nats_connect_timeout_secs: 10 # NATS persistence connection timeout per attempt
@@ -36,7 +36,7 @@ frontend:
 
 # ── Broker ────────────────────────────────────────────────────────────────────
 # Targets, routes, checks, and transforms for the bits routing engine.
-# persistence and internal_poll_endpoint are injected by the chart.
+# persistence and internal_poll_base_url are injected by the chart.
 broker:
   targets:
     worker_pool:


### PR DESCRIPTION
## Summary

Aligns the chart's frontend/broker keys with the bits-broker config schema's tightened naming conventions:

| Before | After |
|---|---|
| `frontend.persist_after_secs: 10.0` (float seconds) | `frontend.persist_after_ms: 10000` (int ms) |
| `internal_poll_endpoint` | `internal_poll_base_url` |

Default value preserved (10 s = 10000 ms). The same rename in `polytope-config` lands as a paired commit in the matching PR there.

Continuation of the config-cleanup migration that started with #35.