### PR TITLE
feat(chart): require polytope.site/env, match bits config schema rename

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -1,3 +1,11 @@
+{{- $site := required "polytope.site is required and must be a lowercase alphanumeric tag of 1-3 characters" .Values.polytope.site -}}
+{{- $env := required "polytope.env is required and must be a lowercase alphanumeric tag of 1-3 characters" .Values.polytope.env -}}
+{{- if not (regexMatch "^[a-z0-9]{1,3}$" $site) -}}
+{{- fail "polytope.site must be a lowercase alphanumeric tag of 1-3 characters" -}}
+{{- end -}}
+{{- if not (regexMatch "^[a-z0-9]{1,3}$" $env) -}}
+{{- fail "polytope.env must be a lowercase alphanumeric tag of 1-3 characters" -}}
+{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,6 +14,9 @@ metadata:
     {{- include "polytope-server.labels" . | nindent 4 }}
 data:
   config.yaml: |
+    polytope:
+      site: {{ $site | quote }}
+      env: {{ $env | quote }}
     server:
       host: {{ .Values.frontend.host | default "0.0.0.0" | quote }}
       port: {{ .Values.frontend.port | default 3000 }}
@@ -29,8 +40,8 @@ data:
           init_max_attempts: {{ . }}
           {{- end }}
         {{- end }}
-        internal_poll_base_url: {{ include "polytope-server.pollBaseUrl" . | quote }}
-        persist_after_ms: {{ .Values.frontend.persist_after_ms | default 10000 }}
+        internal_poll_endpoint: {{ include "polytope-server.pollBaseUrl" . | quote }}
+        persist_after_secs: {{ .Values.frontend.persist_after_secs | default 10 }}
         worker_server:
           host: "0.0.0.0"
           port: {{ .Values.frontend.brokerPort | default 9001 }}

--- a/values.yaml
+++ b/values.yaml
@@ -16,6 +16,13 @@ global:
 # Additional pull secrets for the parent chart only (merged with global).
 imagePullSecrets: []
 
+# ── Polytope identity ─────────────────────────────────────────────────────────
+# Stable 1-3 character lowercase alphanumeric tags used in persisted request IDs.
+# Set explicitly from deployment values; these are not inferred from Kubernetes.
+polytope:
+  site: ""
+  env: ""
+
 # ── Frontend (broker) ─────────────────────────────────────────────────────────
 frontend:
   image:
@@ -26,7 +33,7 @@ frontend:
   port: 3000
   brokerPort: 9001
   replicas: 1
-  persist_after_ms: 10000
+  persist_after_secs: 10
   # max_jobs: 500000              # Broker-wide job limit (OOM protection, default 500000)
   # retry_after_secs: 5           # Retry-After header on 529 overload responses
   # nats_connect_timeout_secs: 10 # NATS persistence connection timeout per attempt
@@ -36,7 +43,7 @@ frontend:
 
 # ── Broker ────────────────────────────────────────────────────────────────────
 # Targets, routes, checks, and transforms for the bits routing engine.
-# persistence and internal_poll_base_url are injected by the chart.
+# persistence and internal_poll_endpoint are injected by the chart.
 broker:
   targets:
     worker_pool:


### PR DESCRIPTION
## Summary

Two paired changes that land with the polytope-server / bits request-id-redesign work:

### 1. Polytope identity validation

- Add `polytope.site` and `polytope.env` as required values; both must be 1-3 char lowercase alphanumeric tags.
- Render-time validation in `templates/configmap.yaml` fails fast with a clear message when missing or malformed.
- Inject `polytope.site`/`env` into the rendered server config so polytope-server picks them up at startup.

### 2. Bits config schema rename

- Reverts the rename done in #38: bits' current config keys are `internal_poll_endpoint` and `persist_after_secs` (float seconds), not `internal_poll_base_url` / `persist_after_ms`. Match bits.

## Test plan

Tested via `helm template` with valid + each of three invalid combinations (missing, uppercase, >3 chars) plus a clean render that confirms the rendered configmap carries `polytope: site/env`, `internal_poll_endpoint`, and `persist_after_secs`. Live-deployed against `bologna-dps-dev` as part of this work and confirmed end-to-end (26-char Crockford ID with `site=bol env=dev` decoded prefix).

## Coupling

Pairs with:
- bits PR (request-id-redesign branch).
- polytope-server PR (paired wiring).
- polytope-config PR (per-env/location identity values, paired rename).

Land bits + polytope-server first; this chart change requires both to deploy meaningfully.
