### PR TITLE
fix(networkpolicy): allow internal metrics scraping

### DIFF
--- a/templates/frontend-networkpolicy.yaml
+++ b/templates/frontend-networkpolicy.yaml
@@ -36,12 +36,8 @@ spec:
         - port: internal-poll
           protocol: TCP
     {{- if .Values.telemetry.enabled }}
-    # Prometheus scrape from monitoring namespace.
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: monitoring
-      ports:
+    # Metrics remain internal to the cluster, but are reachable from any namespace.
+    - ports:
         - port: metrics
           protocol: TCP
     {{- end }}


### PR DESCRIPTION
## Summary

- allow the frontend metrics port to be scraped from any namespace
- retain the frontend NetworkPolicy restrictions for broker and internal-poll traffic
- keep metrics internal: the port is exposed only through the ClusterIP service and is not routed by the public Ingress

## Verification

- `helm lint . --strict`
- `./tests/run.sh`
